### PR TITLE
Fix math domain errors

### DIFF
--- a/webcam_teleop_interface.py
+++ b/webcam_teleop_interface.py
@@ -161,7 +161,7 @@ class WebcamArucoDetector:
                 ratio = np.clip(ratio, a_min=-1, a_max=1)
 
                 variable_angle = math.asin(ratio)
-                
+
                 if self.debug_side_marker: 
                     print('tongs_pin_joint_to_marker_cecnter = {:.2f} cm'.format(self.tongs_pin_joint_to_marker_center * 100.0))
                     print('distance_between_markers = {:.2f} cm'.format(distance_between_markers * 100.0))
@@ -413,10 +413,10 @@ class WebcamArucoDetector:
             h2 = hypotenuse * hypotenuse
             o2 = opposite_side * opposite_side
 
-            if o2 >= h2:
-                o2 = h2
+            difference_pythagorean = h2 - o2
+            difference_pythagorean = np.clip(difference_pythagorean, 0.01, float('inf'))
 
-            adjacent_side = math.sqrt(h2 - o2)
+            adjacent_side = math.sqrt(difference_pythagorean)
             grip_pos = grip_pos + (-(adjacent_side) * grip_y_axis)
             
                 

--- a/webcam_teleop_interface.py
+++ b/webcam_teleop_interface.py
@@ -156,7 +156,12 @@ class WebcamArucoDetector:
                 distance_between_markers = grip_width
                 hypotenuse = self.tongs_pin_joint_to_marker_center
                 opposite_side = distance_between_markers / 2.0
-                variable_angle = math.asin(opposite_side/hypotenuse)
+
+                ratio = opposite_side / hypotenuse
+                ratio = np.clip(ratio, a_min=-1, a_max=1)
+
+                variable_angle = math.asin(ratio)
+                
                 if self.debug_side_marker: 
                     print('tongs_pin_joint_to_marker_cecnter = {:.2f} cm'.format(self.tongs_pin_joint_to_marker_center * 100.0))
                     print('distance_between_markers = {:.2f} cm'.format(distance_between_markers * 100.0))
@@ -404,7 +409,14 @@ class WebcamArucoDetector:
                 distance_between_markers = self.tongs_open_grip_width
             hypotenuse = self.tongs_pin_joint_to_marker_center
             opposite_side = distance_between_markers / 2.0
-            adjacent_side = math.sqrt((hypotenuse * hypotenuse) - (opposite_side * opposite_side))
+            
+            h2 = hypotenuse * hypotenuse
+            o2 = opposite_side * opposite_side
+
+            if o2 >= h2:
+                o2 = h2
+
+            adjacent_side = math.sqrt(h2 - o2)
             grip_pos = grip_pos + (-(adjacent_side) * grip_y_axis)
             
                 


### PR DESCRIPTION
In some gripper configurations, the argument for `math.asin()` would exceed `[-1, 1]` or the argument for `math.sqrt()` would be negative. This PR clamps the values for both of those function calls.