### PR TITLE
Give lift motor 75% of max applied torque during fast mode

### DIFF
--- a/robot_move.py
+++ b/robot_move.py
@@ -55,7 +55,7 @@ class RobotMove:
                     #'joint_lift': (None, {'v_m': 0.13, 'a_m': 1.0}),
                     custom_parameters = {
                         'joint_mobile_base_rotate_by': (None, {'v_r': 0.3, 'a_r': 0.5}),
-                        'joint_lift': (None, {'v_m': 0.2, 'a_m': 1.0}),
+                        'joint_lift': (None, {'v_m': 0.2, 'a_m': 1.0, 'contact_thresh_pos': 75.0}),
                         'joint_arm_l0': (None, {'v_m': 0.18, 'a_m': 1.0}),
                         'joint_wrist_yaw': ('wrist_yaw', {'v_r': 3.0, 'a_r': 10}),
                         'joint_wrist_pitch': ('wrist_pitch', {'v_r': 3.0, 'a_r': 10.0}),


### PR DESCRIPTION
For most Stretchs, Dex Teleop's fast mode requires the lift motor to apply higher torques to track (and apply contact according to) the reference trajectory. The default conservative contact sensitivity settings prevent the lift motor from being able to do this, leading to "jerky lift motion". This change gives the motor 75% of its limit, which is reasonable for most Stretchs.

Testing
---------

I've teleop-ed Stretch 3004 with this change for ~1hr, doing a variety of tests. The contact sensitivity is reduced (as expected), but the robot smoothly tracks my motions.