### PR TITLE
Document and enforce charger SUPPLY during Fast Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ python3 dex_teleop.py
 
 ### When You're Ready, Try Fast Motions
 
-Once you are confident that you have the system correctly configured and have learned to use it at the slowest speed, you can run the following command to try it at the fastest available speed. **The robot will move fast, so be very careful!**
+Once you are confident that you have the system correctly configured and have learned to use it at the slowest speed, you can run the following command to try it at the fastest available speed. **The robot will move fast, with greatly reduced contact sensitivity, so be very careful!**
 
 ```
 python3 dex_teleop.py --fast
@@ -181,6 +181,16 @@ For example, for the left-hand robot, you can run the following command to try s
 python3 dex_teleop.py --left
 ```
 
+## Troubleshooting
+
+If you're having trouble with the steps in the guide, please check the following tips:
+
+### Arm stops abruptly or moves jerkily during Fast Mode
+
+For most Stretchs, Dex Teleop's fast mode requires the arm/lift motors to apply higher effort to track (and apply contact according to) the reference trajectory. If you're seeing abrupt or jerky motions, try the following tips:
+
+ - The percentage effort the motor needs also varies with the robot's system voltage. For this reason, ensure the robot's charger is plugged in and set to SUPPLY mode when using fast mode in Dex Teleop. Documentation on the charger's SUPPLY mode can be found in the [Battery Maintenance](https://docs.hello-robot.com/0.3/hardware/battery_maintenance_guide_se3/#noco-genius-10-interface) guide.
+ - If the charger is already plugged in, the motors' effort threshold may need to be calibrated. See the [Practical guide to guarded contacts](https://forum.hello-robot.com/t/practical-guide-to-guarded-contacts/654) post for more details on using the `REx_calibrate_guarded_contact.py` CLI. Both the arm and lift motors may need to be recalibrated.
 
 
 ## Acknowledgment

--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ python3 dex_teleop.py
 
 ### When You're Ready, Try Fast Motions
 
-Once you are confident that you have the system correctly configured and have learned to use it at the slowest speed, you can run the following command to try it at the fastest available speed. **The robot will move fast, with greatly reduced contact sensitivity, so be very careful!**
+First, plug the charger into the robot and set the charger to [SUPPLY mode](https://docs.hello-robot.com/0.3/hardware/battery_maintenance_guide_se3/#noco-genius-10-interface).
+
+Then, once you are confident that you have the system correctly configured and have learned to use it at the slowest speed, you can run the following command to try it at the fastest available speed. **The robot will move fast, with greatly reduced contact sensitivity, so be very careful!**
 
 ```
 python3 dex_teleop.py --fast

--- a/dex_teleop.py
+++ b/dex_teleop.py
@@ -32,6 +32,8 @@ if __name__ == '__main__':
     else:
         robot_speed = 'slow'
     print('running with robot_speed =', robot_speed)
+    if use_fastest_mode:
+        print("WARNING: Expect lower contact sensitivity in Fast Mode")
 
     lift_middle = dt.get_lift_middle(manipulate_on_ground)
     center_configuration = dt.get_center_configuration(lift_middle)

--- a/robot_move.py
+++ b/robot_move.py
@@ -11,18 +11,20 @@ class RobotMove:
         self.create_all_commands(robot)
 
         if speed not in self.all_speeds.keys():
-            print('WARNING: RobotMove create_commands called with unrecognized speed = \'' + speed + '\'')
-            print('         Using \'default\' speed instead.')
+            print(f"WARNING: RobotMove create_commands called with unrecognized speed = '{speed}'")
+            print(f"         Using 'default' speed instead.")
             speed = 'default'
 
         # Check robot is homed
         is_homed = robot.is_homed()
         if not is_homed:
+            print("ERROR: Robot must be homed before using Dex Teleop\n")
             raise Exception("Robot must be homed before using Dex Teleop")
 
         # If using fast mode, check charger is plugged in
         is_charging = robot.pimu.status['charger_is_charging']
         if speed in ['fastest_stretch_2', 'fastest_stretch_3'] and not is_charging:
+            print("ERROR: Dex Teleop's fast mode requires the charger to plugged in\n")
             raise Exception("Dex Teleop's fast mode requires the charger to plugged in")
 
         self.speed = speed

--- a/robot_move.py
+++ b/robot_move.py
@@ -14,7 +14,17 @@ class RobotMove:
             print('WARNING: RobotMove create_commands called with unrecognized speed = \'' + speed + '\'')
             print('         Using \'default\' speed instead.')
             speed = 'default'
-        
+
+        # Check robot is homed
+        is_homed = robot.is_homed()
+        if not is_homed:
+            raise Exception("Robot must be homed before using Dex Teleop")
+
+        # If using fast mode, check charger is plugged in
+        is_charging = robot.pimu.status['charger_is_charging']
+        if speed in ['fastest_stretch_2', 'fastest_stretch_3'] and not is_charging:
+            raise Exception("Dex Teleop's fast mode requires the charger to plugged in")
+
         self.speed = speed
         self.move_to_functions = self.all_speeds[self.speed]['move_to_functions']
         self.move_to_settings = self.all_speeds[self.speed]['move_to_settings']


### PR DESCRIPTION
The effort Stretch's motors must apply during Fast Mode varies with the robot's system voltage. A lower voltage (e.g. when not plugged in) requires the motors to exert more effort, which often leads to false positive guarded contact detections. To correct for this variation, it's recommended to plug the robot into the charger's SUPPLY mode during Fast Mode operation. This PR documents and enforces this recommendation by:

 1. Documenting the plug-in step in the README. It is documented a second time in a troubleshooting section.
 2. Checking and error-ing out in RobotMove if the robot doesn't detect charge.

Additionally, this PR adds warnings to the documentation and to the command line that the lift's contact detection will be less sensitive when running Dex Teleop in Fast Mode. Lastly, as a small bonus, this PR adds a check and errors out if the robot is not homed.